### PR TITLE
Basic macOS GCC build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Note: This is only tested on Ubuntu 20.04. If you have experience in multi-distr
 
 ### macOS
 
-Note: AmalgamEngine requires GCC to build on MacOS. Clang / Apple Clang does not yet support C++ features required by this project (as of Apple Clang 14 / Clang 15).
+Note: AmalgamEngine requires GCC to build on macOS. Clang / Apple Clang does not yet support C++ features required by this project (as of Apple Clang 14 / Clang 15).
 
 1. Use the Homebrew package manager to install dependencies: `brew install gcc make cmake ninja sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_gfx sdl2_net`
-1. (From the base of the repo) `mkdir -p Build/MacOS/Release`
-1. `cd Build/MacOS/Release`
+1. (From the base of the repo) `mkdir -p Build/macOS/Release`
+1. `cd Build/macOS/Release`
 1. `CC=gcc-XX CXX=g++-XX cmake -DCMAKE_BUILD_TYPE=Release -G Ninja ../../../`. Replace the `XX` in `gcc-XX` and `g++-XX` with the version of GCC that you installed with Homebrew. This is important, as using `gcc` without a version number will alias to `clang`.
-   1. ~~You can optionally add `-DAM_BUILD_SPRITE_EDITOR` to build the sprite editor.~~ Sprite editor doesn't currently build on MacOS due to GCC not being able to build with Apple SDK headers which use certain Objective C extensions.
+   1. ~~You can optionally add `-DAM_BUILD_SPRITE_EDITOR` to build the sprite editor.~~ Sprite editor doesn't currently build on macOS due to GCC not being able to build with Apple SDK headers which use certain Objective C extensions.
 1. `ninja all`
 
 ## Packaging

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Note: This is only tested on Ubuntu 20.04. If you have experience in multi-distr
    1. You can optionally add `-DAM_BUILD_SPRITE_EDITOR` to build the sprite editor.
 1. `ninja all`
 
+### macOS
+
+Note: AmalgamEngine requires GCC to build on MacOS. Clang / Apple Clang does not yet support C++ features required by this project (as of Apple Clang 14 / Clang 15).
+
+1. Use the Homebrew package manager to install dependencies: `brew install gcc make cmake ninja sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_gfx sdl2_net`
+1. (From the base of the repo) `mkdir -p Build/MacOS/Release`
+1. `cd Build/MacOS/Release`
+1. `CC=gcc-XX CXX=g++-XX cmake -DCMAKE_BUILD_TYPE=Release -G Ninja ../../../`. Replace the `XX` in `gcc-XX` and `g++-XX` with the version of GCC that you installed with Homebrew. This is important, as using `gcc` without a version number will alias to `clang`.
+   1. ~~You can optionally add `-DAM_BUILD_SPRITE_EDITOR` to build the sprite editor.~~ Sprite editor doesn't currently build on MacOS due to GCC not being able to build with Apple SDK headers which use certain Objective C extensions.
+1. `ninja all`
+
 ## Packaging
 Note: You rarely need to package the engine by itself, this section just provides canonical instructions. Instead, see the Template Projects section.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Note: AmalgamEngine requires GCC to build on macOS. Clang / Apple Clang does not
 1. Use the Homebrew package manager to install dependencies: `brew install gcc make cmake ninja sdl2 sdl2_image sdl2_mixer sdl2_ttf sdl2_gfx sdl2_net`
 1. (From the base of the repo) `mkdir -p Build/macOS/Release`
 1. `cd Build/macOS/Release`
-1. `CC=gcc-XX CXX=g++-XX cmake -DCMAKE_BUILD_TYPE=Release -G Ninja ../../../`. Replace the `XX` in `gcc-XX` and `g++-XX` with the version of GCC that you installed with Homebrew. This is important, as using `gcc` without a version number will alias to `clang`.
+1. `CC=gcc-NN CXX=g++-NN cmake -DCMAKE_BUILD_TYPE=Release -G Ninja ../../../`. Replace the `NN` in `gcc-NN` and `g++-NN` with the version of GCC that you installed with Homebrew. This is important, as using `gcc` without a version number will alias to `clang`.
    1. ~~You can optionally add `-DAM_BUILD_SPRITE_EDITOR` to build the sprite editor.~~ Sprite editor doesn't currently build on macOS due to GCC not being able to build with Apple SDK headers which use certain Objective C extensions.
 1. `ninja all`
 

--- a/Source/ClientLib/CMakeLists.txt
+++ b/Source/ClientLib/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(ClientLib
 )
 
 # Inherit Shared's precompiled header.
-# CMake causes issues when using precompiled headers with GCC on MacOS,
+# CMake causes issues when using precompiled headers with GCC on macOS,
 # so precompiled headers as disabled for that target.
 if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
     target_precompile_headers(ClientLib REUSE_FROM SharedLib)

--- a/Source/ClientLib/CMakeLists.txt
+++ b/Source/ClientLib/CMakeLists.txt
@@ -18,8 +18,8 @@ target_include_directories(ClientLib
 
 # Inherit Shared's precompiled header.
 # CMake causes issues when using precompiled headers with GCC on macOS,
-# so precompiled headers as disabled for that target.
-if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+# so precompiled headers are disabled for that target.
+if ((NOT APPLE) OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang"))
     target_precompile_headers(ClientLib REUSE_FROM SharedLib)
 endif()
 

--- a/Source/ClientLib/CMakeLists.txt
+++ b/Source/ClientLib/CMakeLists.txt
@@ -17,7 +17,11 @@ target_include_directories(ClientLib
 )
 
 # Inherit Shared's precompiled header.
-target_precompile_headers(ClientLib REUSE_FROM SharedLib)
+# CMake causes issues when using precompiled headers with GCC on MacOS,
+# so precompiled headers as disabled for that target.
+if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+    target_precompile_headers(ClientLib REUSE_FROM SharedLib)
+endif()
 
 target_link_libraries(ClientLib
     PUBLIC

--- a/Source/ServerLib/CMakeLists.txt
+++ b/Source/ServerLib/CMakeLists.txt
@@ -17,7 +17,11 @@ target_include_directories(ServerLib
 )
 
 # Inherit Shared's precompiled header.
-target_precompile_headers(ServerLib REUSE_FROM SharedLib)
+# CMake causes issues when using precompiled headers with GCC on MacOS,
+# so precompiled headers as disabled for that target.
+if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+    target_precompile_headers(ServerLib REUSE_FROM SharedLib)
+endif()
 
 target_link_libraries(ServerLib
     PUBLIC

--- a/Source/ServerLib/CMakeLists.txt
+++ b/Source/ServerLib/CMakeLists.txt
@@ -18,8 +18,8 @@ target_include_directories(ServerLib
 
 # Inherit Shared's precompiled header.
 # CMake causes issues when using precompiled headers with GCC on macOS,
-# so precompiled headers as disabled for that target.
-if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+# so precompiled headers are disabled for that target.
+if ((NOT APPLE) OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang"))
     target_precompile_headers(ServerLib REUSE_FROM SharedLib)
 endif()
 

--- a/Source/ServerLib/CMakeLists.txt
+++ b/Source/ServerLib/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(ServerLib
 )
 
 # Inherit Shared's precompiled header.
-# CMake causes issues when using precompiled headers with GCC on MacOS,
+# CMake causes issues when using precompiled headers with GCC on macOS,
 # so precompiled headers as disabled for that target.
 if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
     target_precompile_headers(ServerLib REUSE_FROM SharedLib)

--- a/Source/SharedLib/Utility/CMakeLists.txt
+++ b/Source/SharedLib/Utility/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(SharedLib
 
 # Build our precompiled header.
 # CMake causes issues when using precompiled headers with GCC on macOS,
-# so precompiled headers as disabled for that target.
-if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+# so precompiled headers are disabled for that target.
+if ((NOT APPLE) OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang"))
     target_precompile_headers(SharedLib PRIVATE Private/pch.h)
 endif()

--- a/Source/SharedLib/Utility/CMakeLists.txt
+++ b/Source/SharedLib/Utility/CMakeLists.txt
@@ -38,4 +38,8 @@ target_include_directories(SharedLib
 )
 
 # Build our precompiled header.
-target_precompile_headers(SharedLib PRIVATE Private/pch.h)
+# CMake causes issues when using precompiled headers with GCC on MacOS,
+# so precompiled headers as disabled for that target.
+if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+    target_precompile_headers(SharedLib PRIVATE Private/pch.h)
+endif()

--- a/Source/SharedLib/Utility/CMakeLists.txt
+++ b/Source/SharedLib/Utility/CMakeLists.txt
@@ -38,7 +38,7 @@ target_include_directories(SharedLib
 )
 
 # Build our precompiled header.
-# CMake causes issues when using precompiled headers with GCC on MacOS,
+# CMake causes issues when using precompiled headers with GCC on macOS,
 # so precompiled headers as disabled for that target.
 if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
     target_precompile_headers(SharedLib PRIVATE Private/pch.h)

--- a/Source/SpriteEditor/CMakeLists.txt
+++ b/Source/SpriteEditor/CMakeLists.txt
@@ -15,7 +15,11 @@ target_include_directories(SpriteEditor
 )
 
 # Inherit Shared's precompiled header.
-target_precompile_headers(SpriteEditor REUSE_FROM SharedLib)
+# CMake causes issues when using precompiled headers with GCC on MacOS,
+# so precompiled headers as disabled for that target.
+if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+    target_precompile_headers(SpriteEditor REUSE_FROM SharedLib)
+endif()
 
 target_link_libraries(SpriteEditor
     PRIVATE

--- a/Source/SpriteEditor/CMakeLists.txt
+++ b/Source/SpriteEditor/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(SpriteEditor
 )
 
 # Inherit Shared's precompiled header.
-# CMake causes issues when using precompiled headers with GCC on MacOS,
+# CMake causes issues when using precompiled headers with GCC on macOS,
 # so precompiled headers as disabled for that target.
 if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
     target_precompile_headers(SpriteEditor REUSE_FROM SharedLib)

--- a/Source/SpriteEditor/CMakeLists.txt
+++ b/Source/SpriteEditor/CMakeLists.txt
@@ -16,8 +16,8 @@ target_include_directories(SpriteEditor
 
 # Inherit Shared's precompiled header.
 # CMake causes issues when using precompiled headers with GCC on macOS,
-# so precompiled headers as disabled for that target.
-if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+# so precompiled headers are disabled for that target.
+if ((NOT APPLE) OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang"))
     target_precompile_headers(SpriteEditor REUSE_FROM SharedLib)
 endif()
 

--- a/Source/Tests/TestSandboxes/Network/LoadTest/CMakeLists.txt
+++ b/Source/Tests/TestSandboxes/Network/LoadTest/CMakeLists.txt
@@ -35,8 +35,8 @@ target_include_directories(LoadTestClient
 
 # Inherit Shared's precompiled header.
 # CMake causes issues when using precompiled headers with GCC on macOS,
-# so precompiled headers as disabled for that target.
-if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+# so precompiled headers are disabled for that target.
+if ((NOT APPLE) OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang"))
     target_precompile_headers(LoadTestClient REUSE_FROM SharedLib)
 endif()
 

--- a/Source/Tests/TestSandboxes/Network/LoadTest/CMakeLists.txt
+++ b/Source/Tests/TestSandboxes/Network/LoadTest/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(LoadTestClient
 )
 
 # Inherit Shared's precompiled header.
-# CMake causes issues when using precompiled headers with GCC on MacOS,
+# CMake causes issues when using precompiled headers with GCC on macOS,
 # so precompiled headers as disabled for that target.
 if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
     target_precompile_headers(LoadTestClient REUSE_FROM SharedLib)

--- a/Source/Tests/TestSandboxes/Network/LoadTest/CMakeLists.txt
+++ b/Source/Tests/TestSandboxes/Network/LoadTest/CMakeLists.txt
@@ -34,7 +34,11 @@ target_include_directories(LoadTestClient
 )
 
 # Inherit Shared's precompiled header.
-target_precompile_headers(LoadTestClient REUSE_FROM SharedLib)
+# CMake causes issues when using precompiled headers with GCC on MacOS,
+# so precompiled headers as disabled for that target.
+if (NOT APPLE OR CMAKE_C_COMPILER_ID MATCHES "Clang|AppleClang")
+    target_precompile_headers(LoadTestClient REUSE_FROM SharedLib)
+endif()
 
 target_link_libraries(LoadTestClient
     PRIVATE


### PR DESCRIPTION
<img width="1600" alt="repose" src="https://user-images.githubusercontent.com/41816363/223019718-3bc6f44b-5474-4617-8814-18d59e66fa88.png">

Tested with GCC 12 on macOS 12 (M1 processor).

This PR:
- Updates readerwriterqueue to the latest version, to fix compiling it with GCC on macOS.
- Modifies CMake scripts to not use precompiled headers with GCC on macOS, due to CMake using incompatible compiler flags.
- Adds instructions for building on macOS.

No code needs to be changed for this to work. Clang (the default compiler on macOS) hasn't implemented some C++ features used in this project (["parenthesised aggregate initialisation"](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0960r3.html), aka allowing `emplace_back(...)` to initialise structs), so GCC is used instead.

Note that this doesn't build a macOS app bundle, it just creates an executable file that can be run from the terminal. I might submit a PR to build an app bundle in the future, but distributing macOS apps is a pain due to signing.